### PR TITLE
ci: scheduled runs on Monday, Wednesday & Friday

### DIFF
--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -8,7 +8,7 @@ env:
 
 on:
   schedule:
-    - cron: "*/15 * * * *" # every 15 minutes
+    - cron: "0 5 * * 1,3,5" # monday,wednesday,friday 5AM
   workflow_dispatch:
     inputs:
       version:


### PR DESCRIPTION
- Reverts https://github.com/stackblitz/webcontainer-ecosystem-ci/pull/9 now that README badge is up-to-date